### PR TITLE
Better describe ABI features and standard library addition

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -278,16 +278,20 @@ attribute should be documented in the Python standard library documentation.
 Reference Implementation
 ========================
 
-The reference implementation consists purely in an updated version of the
-`packaging` library.
-The implementation is available at
-https://github.com/zklaus/packaging/tree/env-marker-free-threading.
-A demonstration package is available at
-https://github.com/zklaus/env-marker-example.
+The reference implementation for the ``sys.abi_features`` attribute can be
+found in `Add abi_features to sys <https://github.com/zklaus/cpython/pull/1>`_.
+
+The reference implementation for the environment markers is available in a fork
+of the `packaging` library at `Environment markers for ABI features
+<https://github.com/zklaus/packaging/pull/1>`_.
+
+`A demonstration package <https://github.com/zklaus/env-marker-example>`_ is
+also available.
+
 Since `pip` uses a vendored copy of `packaging` internally, we also provide
-a patched version of `pip` at
-https://github.com/zklaus/pip/tree/env-marker-free-threading, which is based on
-pypa/pip:main with the vendored `packaging` replaced by the reference
+`a patched version of pip
+<https://github.com/zklaus/pip/tree/env-marker-free-threading>`_, which is
+based on pypa/pip:main with the vendored `packaging` replaced by the reference
 implementation linked above.
 
 Rejected Ideas

--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -1,6 +1,7 @@
 PEP: 790
 Title: New environment markers for modern Python environments
-Author: Klaus Zimmermann <klaus.zimmermann@quansight.com>
+Author: Klaus Zimmermann <klaus_zimmermann@gmx.de>,
+        Ralf Gommers <ralf.gommers@gmail.com>
 Sponsor: <name of sponsor>
 PEP-Delegate: <PEP delegate's name>
 Discussions-To: https://discuss.python.org/t/environment-marker-for-free-threading/60007
@@ -356,7 +357,8 @@ Footnotes
 Acknowledgements
 ================
 
-Thanks to Stephen Rosen for the Backwards Compatibility section of :pep:`735`,
+Thanks to Filipe Laíns for the suggestion of the ``abi_features`` attribute
+and to Stephen Rosen for the Backwards Compatibility section of :pep:`735`,
 which served as a template for the corresponding section in this PEP.
 
 Copyright

--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -102,41 +102,21 @@ or, explicitly for a non-free threading build::
 Concepts
 --------
 
-We introduces the new marker variable ``sys_abi_features``, corresponding to a
-list of proper feature names that give more accessible information about the
-interpreters ABI.
-
-This requires firstly an extension of the dependency specifier grammar,
-and secondly a specification of the ABI features as encoded in the marker
-variable.
-
-Grammar
--------
-
-The grammar laid out in :pep:`508` and maintained in the
-:ref:`packaging:dependency-specifiers` will be extended to include the
-``sys_abi_features`` marker by augmenting the definition of ``env_var``
-as follows::
-
-    env_var       = ('python_version' | 'python_full_version' |
-                     'os_name' | 'sys_platform' | 'platform_release' |
-                     'platform_system' | 'platform_version' |
-                     'platform_machine' | 'platform_python_implementation' |
-                     'implementation_name' | 'implementation_version' |
-                     'sys_abi_features' |
-                     'extra' # ONLY when defined by a containing layer
-                     )
-
+We introduce ABI features as a clear description of certain properties of the
+Python interpreter.
+While some of these features can be queried already today, they are not easily
+nor uniformly accessible.
+Hence, after introducing the features themselves, we propose to add them to the
+Python standard library as ``sys.abi_features``, and to make them available as
+the new environment marker variable ``sys_abi_features``.
 
 ABI Features
-------------
+''''''''''''
 
-The ``sys_abi_features`` marker is a set of strings describing the available
-ABI features as listed below.
-This allows for simple testing of the presence of a single feature using the
-``in`` operator.
+ABI features are intrinsic properties of the Python interpreter, expressed as
+simple, understandable strings.
 
-The following ABI features are defined:
+We propose the following ABI features:
 
 ``free-threading``
     The Python interpreter is free-threading. On Unix systems, this corresponds
@@ -148,7 +128,51 @@ The following ABI features are defined:
 
 ``32-bit`` or ``64-bit``
     The bitness of the interpreter, that is, whether it is a 32-bit or 64-bit
-    build [#bitness]_. 
+    build [#bitness]_.
+
+Addition to the Python Standard Library
+'''''''''''''''''''''''''''''''''''''''
+
+Making the ABI features available in an easily accessible, expressive,
+standardized way is useful beyond the scope of environment markers.
+For example, ``"32-bit" in sys.abi_features`` is much more expressive than the
+current standard test of comparing ``sys.maxsize`` with  ``2**32``, which can
+be found more than tenthousand times on GitHub.
+If one wants to determine whether the interpreter is a debug build, there is
+currently no standardized, cross platform way to do so.
+Hence we suggest to add the `ABI features`_ listed above to the Python standard
+library.
+
+Since they are all the result of compile time choices describing basic features
+of the interpreter, the most intuitive place to put them is in ``sys``.
+Since there is no intrinsic order, nor a possibility for duplication, we
+propose to add them as a frozen set of strings.
+The suggested name is ``sys.abi_features``.
+
+Hence, an example value would be ``sys.abi_features == {"free-threading",
+"debug", "32-bit"}`` on a free-threading debug build for win32.
+
+Environment Markers
+'''''''''''''''''''
+
+To make ABI features available in dependency specifications, we propose to
+introduce a new environment marker variable ``sys_abi_features`` with the same
+semantics as the ``sys.abi_features`` attribute proposed above.
+
+To do this, we need to extend the grammar laid out in :pep:`508` and maintained
+in the :ref:`packaging:dependency-specifiers` and document the possible values.
+
+The grammar will be extended to include the ``sys_abi_features`` marker
+variable by augmenting the definition of ``env_var`` as follows::
+
+    env_var       = ('python_version' | 'python_full_version' |
+                     'os_name' | 'sys_platform' | 'platform_release' |
+                     'platform_system' | 'platform_version' |
+                     'platform_machine' | 'platform_python_implementation' |
+                     'implementation_name' | 'implementation_version' |
+                     'sys_abi_features' |
+                     'extra' # ONLY when defined by a containing layer
+                     )
 
 Like the grammar, also the overview table of environment markers in
 :ref:`packaging:dependency-specifiers` will be augmented to add the following
@@ -164,18 +188,14 @@ row:
       - ``sys.abi_features`` [#sys-abi-features]_
       - ``set()``, ``{"free-threading"}``, ``{"free-threading", "debug"}``
 
-Addition to the Python Standard Library
----------------------------------------
+With these additions, ABI features can be used in dependency specifications via
+the ``in`` operator to test for the presence of a feature, or the ``not in``
+operator to test for the absence of a feature.
 
-Making the ABI features available in an easily accessible, expressive,
-standardized way is useful beyond the scope of environment markers.
-For example, ``"32-bit" in sys.abi_features`` is much more expressive than the
-current standard test of comparing ``sys.maxsize`` with  ``2**32``, which can
-be found more than tenthousand times on GitHub.
-If one wants to determine whether the interpreter is a debug build, there is
-currently no standardized, cross platform way to do so.
-Hence we suggest to add the `ABI features`_ listed above to the Python standard
-library.
+Note that the presence of ``sys.abi_features`` in the Python standard library
+makes implementation particularly easy for new Python versions, but its absence
+in older versions does not prevent the implementation of the new environment
+markers, as demonstrated in the `Reference Implementation`_.
 
 Examples
 ========


### PR DESCRIPTION
This PR clarifies the addition to the standard library. To support this, the description of the the ABI features themselves is separated from their use in the environment markers.