### PR TITLE
First round of feedback for PEP 790

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -21,9 +21,9 @@ Post-History: <REQUIRED: dates, in dd-mmm-yyyy format, and corresponding links t
 Abstract
 ========
 
-This PEP defines new environment markers for package dependencies.
+This PEP defines new environment markers for project dependencies.
 :pep:`508` (later moved to :ref:`packaging:dependency-specifiers`) introduced
-environment markers to specify dependencies based on a rule that describes
+environment markers to specify dependencies based on rules that describe
 when the dependency should be used.
 This PEP extends the environment markers to allow specifying dependencies
 based on specific abi features of the Python interpreter.
@@ -52,27 +52,27 @@ Interpreter Lock (GIL), which allows for free threading
 
 Some real world issues that are addressed by this PEP include the following:
 
-- Cython has support for free-threading only in its master branch, and is used
+- Cython has (experimental) support for free-threading only in its master branch, and is used
   by a lot of projects that already publish cp313t wheels. Picking up the wrong
   Cython version is causing a lot of obscure build failures or runtime crashes.
   It would be quite beneficial if the metadata could express that
   (c.f. `Require Cython pre-release for free-threading Python`_).
 - CFFI has no support for free-threading yet, and the maintainers have stated
-  that it may be a good idea to fork cffi, ensure it starts working with
+  that it may be a good idea to fork cffi, implement support for
   free-threading, and only come back to the CFFI project with a single large PR
   that adds support after the functionality "is reasonably well-tested (either
   as tests or, better in this case, tested by being in use in various other
   projects)". There are a lot of projects that depend on cffi. They are likely
   fine to start depending on a fork for free-threading only, however depending
   on a fork for >=3.13 or for all Python versions seems like a much larger ask,
-  and more disruptive for distro packagers, for example.
+  and more disruptive for distribution packagers, for example.
 
 Another feature that is not yet covered by environment markers is the bitness
-of the interpreter, which is relevant for some packages that provide C
-extensions. For example, Scipy does not provide win32 wheels, which can be
-awkward for projects where Scipy is an optional dependency only. In that case,
-it would be useful to be able to specify that Scipy is required *unless* the
-interpreter is 32-bit win32 (c.f. `Require Scipy unless on 32-bit win32`_).
+of the underlying system the interpreter targets, which is relevant for some packages that provide C
+extensions. For example, SciPy does not provide win32 wheels, which can be
+awkward for projects where SciPy is an optional dependency only. In that case,
+it would be useful to be able to specify that SciPy is required *unless* the
+interpreter is 32-bit win32 (c.f. `Require SciPy unless on 32-bit win32`_).
 
 
 Rationale
@@ -100,22 +100,22 @@ It is therefore important to make sure that the mechanisms in this PEP are
 useable for Python interpreters where either free-threading or
 non-free-threading could be the default or the only option.
 
-At the time of writing, free-threading Python is in Phase I: experimental phase.
+At the time of writing, free-threaded Python is in Phase I: experimental phase.
 In this phase, there is an acute need for the proposed environment markers to
-help with the transition to free-threading Python as package authors gradually
+help with the transition to free-threaded Python as package authors gradually
 add support.
 
 As the number of packages with support increases, and particularly during
 Phase II: Supported-but-not-default phase, we still anticipate a strong need
 for the environment markers to help with the transition.
 
-As free-threading Python enters into Phase III: Default phase, the need for
+As free-threaded Python enters into Phase III: Default phase, the need for
 the environment markers will decrease, though at this point it is not clear
 that the GIL-enabled Python will be completely phased out (it may remain
 available as a non standard build option). If it persists, the inverse need for
 the ABI feature detection may arise.
 
-Indeed, in all three phases it may be necessary for package authors to chose
+Indeed, in all three phases it may be necessary for package authors to choose
 specific versions of their dependencies based on the ABI features, with a shift
 from GIL-enabled as default to free-threading as default over time.
 
@@ -136,7 +136,7 @@ using the following syntax::
 
     cython; "free-threading" in sys_abi_features
 
-or, explicitly for a non-free threading build::
+or, explicitly, for a gil-enabled build::
 
     cython; "free-threading" not in sys_abi_features
 
@@ -147,7 +147,7 @@ ABI features are a clear description of certain properties of the Python
 interpreter. While some of these features can be queried already today, they
 are not easily nor uniformly accessible.
 
-Hence, the proposed feature MUST be made available via the Python standard
+Hence, the proposed feature must be made available via the Python standard
 library as ``sys.abi_features``, and as the new environment marker variable
 ``sys_abi_features``.
 
@@ -156,38 +156,38 @@ ABI Features
 
 ABI features are intrinsic properties of the Python interpreter, expressed as
 simple, understandable strings.
-However, not all feature are equally applicable to all Python interpreters. For
-example, the distinction between free-threading and GIL-enabled interpreters is
-only relevant for CPython, but the bitness of the interpreter is relevant for
-all interpreters.
+However, not all features are equally applicable to all Python interpreters or
+Python versions. For example, the distinction between free-threading and
+GIL-enabled interpreters is only relevant for CPython >=3.13, but the bitness
+of the interpreter is relevant for all interpreters.
 
-All interpreters MUST handle the following ABI features as stated.
-ABI features that are restricted to particular interpreters MUST NOT be
+All interpreters must handle the following ABI features as stated.
+ABI features that are restricted to particular interpreters must not be
 provided by other interpreters.
 
 ``free-threading`` or ``gil-enabled`` (only CPython)
-    If the Python interpreter is free-threading, the ``free-threading`` feature
-    MUST be present and the ``gil-enabled`` feature MUST NOT be present.
-    Otherwise, the ``gil-enabled`` feature MUST be present and the
-    ``free-threading`` feature MUST NOT be present.
+    If the Python interpreter is free-threaded, the ``free-threading`` feature
+    must be present and the ``gil-enabled`` feature must not be present.
+    Otherwise, the ``gil-enabled`` feature must be present and the
+    ``free-threading`` feature must not be present.
 
 ``debug`` (only CPython)
     This ABI feature is reserved for the ``--with-pydebug`` build of CPython.
     If the interpreter is a CPython interpreter with ``Py_DEBUG`` capabilities,
-    the ``debug`` feature MUST be present.
-    On Unix systems, this corresponds to ``"d" in sys.abiflags``.
+    the ``debug`` feature must be present.
+    On POSIX systems, this corresponds to ``"d" in sys.abiflags``.
 
 ``32-bit`` or ``64-bit``
     The bitness of the interpreter, that is, whether it is a 32-bit or 64-bit
     build [#bitness]_.
     
     If the interpreter is a 32-bit build, the ``32-bit`` feature MUST be
-    present and the ``64-bit`` feature MUST NOT be present.
+    present and the ``64-bit`` feature must not be present.
 
-    If the interpreter is a 64-bit build, the ``64-bit`` feature MUST be
-    present and the ``32-bit`` feature MUST NOT be present.
+    If the interpreter is a 64-bit build, the ``64-bit`` feature must be
+    present and the ``32-bit`` feature must not be present.
 
-    If the interpreter is neither, both features MUST NOT be present.
+    If the interpreter is neither, both features must not be present.
 
 Addition to the Python Standard Library
 '''''''''''''''''''''''''''''''''''''''
@@ -196,7 +196,7 @@ Making the ABI features available in an easily accessible, expressive,
 standardized way is useful beyond the scope of environment markers.
 For example, ``"32-bit" in sys.abi_features`` is much more expressive than the
 current standard test of comparing ``sys.maxsize`` with  ``2**32``, which can
-be found more than tenthousand times on GitHub.
+be found more than ten thousand times on GitHub.
 If one wants to determine whether the interpreter is a debug build, there is
 currently no standardized, cross platform way to do so.
 Hence, the `ABI features`_ listed above are added to the Python standard
@@ -207,12 +207,12 @@ of the interpreter, the most intuitive place to put them is in ``sys``.
 Since there is no intrinsic order, nor a possibility for duplication, they are
 added as a ``frozenset`` of strings.
 
-All Python interpreters MUST provide the ``sys.abi_features`` attribute as a
-``frozenset`` of strings, which MUST contain only the `ABI features`_ that are
+All Python interpreters must provide the ``sys.abi_features`` attribute as a
+``frozenset`` of strings, which must contain only the `ABI features`_ that are
 defined in this PEP or in a subsequent PEP.
 
 An example value would be ``sys.abi_features == {"free-threading",
-"debug", "32-bit"}`` on a free-threading debug build for win32.
+"debug", "32-bit"}`` on a free-threaded debug build for win32.
 
 Environment Markers
 '''''''''''''''''''
@@ -264,22 +264,22 @@ Examples
 
 Require Cython pre-release for free-threading Python
 ----------------------------------------------------
-To require a pre-release of Cython only for a free-threading Python
+To require a pre-release of Cython only for a free-threaded Python
 interpreter, the following dependency specification can be used::
 
     cython >3.1.0a1; "free-threading" in sys_abi_features
     cython ==3.0.*; "free-threading" not in sys_abi_features
 
-Require Scipy unless on 32-bit win32
+Require SciPy unless on 32-bit win32
 ------------------------------------
-To require Scipy unless on a 32-bit win32 interpreter, the following
+To require SciPy unless on a 32-bit win32 interpreter, the following
 dependency specification can be used::
 
     scipy; platform_system != "Windows" or "32-bit" not in sys_abi_features
 
 Require Numpy for a free-threading interpreter with debugging capabilities
 --------------------------------------------------------------------------
-To require Numpy only for a free-threading interpreter with debugging
+To require Numpy only for a free-threaded interpreter with debugging
 capabilities, the following dependency can be used::
 
     numpy; "free-threading" in sys_abi_features and "debug" in sys_abi_features
@@ -315,7 +315,7 @@ are encoded.
 Security Implications
 =====================
 
-This PEP introduces new syntaxes for specifying dependency information in
+This PEP introduces new syntax for specifying dependency information in
 projects. However, it does not introduce newly specified mechanisms for
 handling or resolving dependencies.
 


### PR DESCRIPTION
I've left a few minor editorial comments inline in the document. Here's also a few more points that might need a bit of discussion.

- [x] From the abstract, it seems like it's not clear whether the PEP proposes to add `sys.abi_features` to the standard library or not (mainly in the second paragraph). However, in the specification it gives emphasis on how it should be included. I feel we can be more consistent with the messaging here, maybe change how this is phrased in the abstract for example.
- [x] In the motivating example for `cffi`, we should probably mention who is quoted and link to that discussion?
- [x] I feel like there needs to be some more explanation on why we need `sys.abi_features` on top of `sys.abiflags`. The point about availability on non-POSIX systems is one, but we should expand more on how it can serve as a place to document abi features without them appearing as a suffix to the Python executable, which is a major blocker.
- [x] Let's be consistent in using "free-threaded" as an adjective and "free-threading" as a noun. I've tried to highlight this in my inline suggestion, but I might've missed some places.
- [x] Let's avoid caps. Also, `must` appears a lot in the specification and it feels a bit rigid, especially in this stage of the process.
- [ ] All examples use `"free-threading" not in sys_abi_features`, while `"gil-enabled" in sys_abi_features` feels more natural. But this is actually a bigger discussion point. For all of `free-threading`, `debug` and all possible future flags that are mutually exclusive, there's two fairly obvious ways to do the same thing. That feels like a direct contradiction of PEP 20 which states "There should be one-- and preferably only one --obvious way to do it.". I may be way off here, since I don't have much context around the design discussions already held, but could you elaborate a bit on the rationale?